### PR TITLE
Improve readability

### DIFF
--- a/tail.go
+++ b/tail.go
@@ -160,13 +160,13 @@ func (tail *Tail) Tell() (offset int64, err error) {
 
 // Size returns the length in bytes of the file being tailed,
 // or 0 with an error if there was an error Stat'ing the file.
-func (tail *Tail) Size() (size int64, err error) {
+func (tail *Tail) Size() (int64, error) {
 	fi, err := tail.file.Stat()
 	if err != nil {
-		return
+		return 0, err
 	}
-	size = fi.Size()
-	return
+	size := fi.Size()
+	return size, nil
 }
 
 // Stop stops the tailing activity.


### PR DESCRIPTION
named params are hard to follow, even though this is inconsistent with how other methods are defined in this lib I think this is an improvement.