### PR TITLE
Fix locking issue on Windows

### DIFF
--- a/tail.go
+++ b/tail.go
@@ -129,6 +129,7 @@ func TailFile(filename string, config Config) (*Tail, error) {
 		if err != nil {
 			return nil, err
 		}
+		t.watcher.SetFile(t.file)
 	}
 
 	go t.tailFileSync()
@@ -225,6 +226,7 @@ func (tail *Tail) reopen(truncated bool) error {
 		var err error
 		tail.fileMtx.Lock()
 		tail.file, err = OpenFile(tail.Filename)
+		tail.watcher.SetFile(tail.file)
 		tail.fileMtx.Unlock()
 		if err != nil {
 			if os.IsNotExist(err) {

--- a/watch/file_posix.go
+++ b/watch/file_posix.go
@@ -1,0 +1,10 @@
+//go:build linux || darwin || freebsd || netbsd || openbsd
+// +build linux darwin freebsd netbsd openbsd
+
+package watch
+
+import "os"
+
+func IsDeletePending(_ *os.File) (bool, error) {
+	return false, nil
+}

--- a/watch/file_windows.go
+++ b/watch/file_windows.go
@@ -1,0 +1,48 @@
+//go:build windows
+// +build windows
+
+package watch
+
+import (
+	"os"
+	"runtime"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+func IsDeletePending(f *os.File) (bool, error) {
+	if f == nil {
+		return false, nil
+	}
+
+	fi, err := getFileStandardInfo(f)
+	if err != nil {
+		return false, err
+	}
+
+	return fi.DeletePending, nil
+}
+
+// From: https://github.com/microsoft/go-winio/blob/main/fileinfo.go
+// FileStandardInfo contains extended information for the file.
+// FILE_STANDARD_INFO in WinBase.h
+// https://docs.microsoft.com/en-us/windows/win32/api/winbase/ns-winbase-file_standard_info
+type fileStandardInfo struct {
+	AllocationSize, EndOfFile int64
+	NumberOfLinks             uint32
+	DeletePending, Directory  bool
+}
+
+// GetFileStandardInfo retrieves ended information for the file.
+func getFileStandardInfo(f *os.File) (*fileStandardInfo, error) {
+	si := &fileStandardInfo{}
+	if err := windows.GetFileInformationByHandleEx(windows.Handle(f.Fd()),
+		windows.FileStandardInfo,
+		(*byte)(unsafe.Pointer(si)),
+		uint32(unsafe.Sizeof(*si))); err != nil {
+		return nil, &os.PathError{Op: "GetFileInformationByHandleEx", Path: f.Name(), Err: err}
+	}
+	runtime.KeepAlive(f)
+	return si, nil
+}

--- a/watch/inotify.go
+++ b/watch/inotify.go
@@ -133,3 +133,5 @@ func (fw *InotifyFileWatcher) ChangeEvents(t *tomb.Tomb, pos int64) (*FileChange
 
 	return changes, nil
 }
+
+func (fw *InotifyFileWatcher) SetFile(_ *os.File) {}

--- a/watch/watch.go
+++ b/watch/watch.go
@@ -3,7 +3,10 @@
 
 package watch
 
-import "gopkg.in/tomb.v1"
+import (
+	"gopkg.in/tomb.v1"
+	"os"
+)
 
 // FileWatcher monitors file-level events.
 type FileWatcher interface {
@@ -17,4 +20,6 @@ type FileWatcher interface {
 	// In order to properly report truncations, ChangeEvents requires
 	// the caller to pass their current offset in the file.
 	ChangeEvents(*tomb.Tomb, int64) (*FileChanges, error)
+
+	SetFile(f *os.File)
 }


### PR DESCRIPTION
Sometime a file is deleted but, instead of deleting the file, Windows puts it into the state `DeletePending` which isn't detected by this library. This PR detects the `DeletePending` state and responds by closing the file.