### PR TITLE
Rename module to github.com/grafana/tail

### DIFF
--- a/cmd/gotail/gotail.go
+++ b/cmd/gotail/gotail.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/hpcloud/tail"
+	"github.com/grafana/tail"
 )
 
 func args2config() (tail.Config, int64) {

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,10 @@
-module github.com/hpcloud/tail
+module github.com/grafana/tail
 
 go 1.13
 
 require (
-	golang.org/x/sys v0.0.0-20191119060738-e882bf8e40c2 // indirect
-	gopkg.in/fsnotify.v1 v1.2.1 // indirect
+	github.com/fsnotify/fsnotify v1.6.0 // indirect
+	golang.org/x/sys v0.0.0-20220908164124-27713097b956
 	gopkg.in/fsnotify/fsnotify.v1 v1.4.7
 	gopkg.in/tomb.v1 v1.0.0-20140529071818-c131134a1947
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,7 @@
-golang.org/x/sys v0.0.0-20191119060738-e882bf8e40c2 h1:wAW1U21MfVN0sUipAD8952TBjGXMRHFKQugDlQ9RwwE=
-golang.org/x/sys v0.0.0-20191119060738-e882bf8e40c2/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-gopkg.in/fsnotify.v1 v1.2.1/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
+github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
+github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
+golang.org/x/sys v0.0.0-20220908164124-27713097b956 h1:XeJjHH1KiLpKGb6lvMiksZ9l0fVUh+AmGcm0nOMEBOY=
+golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 gopkg.in/fsnotify/fsnotify.v1 v1.4.7 h1:XNNYLJHt73EyYiCZi6+xjupS9CpvmiDgjPTAjrBlQbo=
 gopkg.in/fsnotify/fsnotify.v1 v1.4.7/go.mod h1:Fyux9zXlo4rWoMSIzpn9fDAYjalPqJ/K1qJ27s+7ltE=
 gopkg.in/tomb.v1 v1.0.0-20140529071818-c131134a1947 h1:aNEcl02ps/eZaBJi2LycKl0jPsUryySSSgrCxieZRYA=

--- a/tail.go
+++ b/tail.go
@@ -15,9 +15,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/hpcloud/tail/ratelimiter"
-	"github.com/hpcloud/tail/util"
-	"github.com/hpcloud/tail/watch"
+	"github.com/grafana/tail/ratelimiter"
+	"github.com/grafana/tail/util"
+	"github.com/grafana/tail/watch"
 	"gopkg.in/tomb.v1"
 )
 

--- a/tail_test.go
+++ b/tail_test.go
@@ -14,8 +14,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hpcloud/tail/ratelimiter"
-	"github.com/hpcloud/tail/watch"
+	"github.com/grafana/tail/ratelimiter"
+	"github.com/grafana/tail/watch"
 )
 
 func init() {

--- a/tail_windows.go
+++ b/tail_windows.go
@@ -3,7 +3,7 @@
 package tail
 
 import (
-	"github.com/hpcloud/tail/winfile"
+	"github.com/grafana/tail/winfile"
 	"os"
 )
 

--- a/watch/inotify.go
+++ b/watch/inotify.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/hpcloud/tail/util"
+	"github.com/grafana/tail/util"
 
 	"gopkg.in/fsnotify/fsnotify.v1"
 	"gopkg.in/tomb.v1"

--- a/watch/inotify_tracker.go
+++ b/watch/inotify_tracker.go
@@ -10,7 +10,7 @@ import (
 	"sync"
 	"syscall"
 
-	"github.com/hpcloud/tail/util"
+	"github.com/grafana/tail/util"
 
 	"gopkg.in/fsnotify/fsnotify.v1"
 )

--- a/watch/polling.go
+++ b/watch/polling.go
@@ -4,7 +4,7 @@
 package watch
 
 import (
-	"github.com/hpcloud/tail/util"
+	"github.com/grafana/tail/util"
 	"gopkg.in/tomb.v1"
 	"os"
 	"runtime"


### PR DESCRIPTION
The upstream repo [github.com/hpcloud/tail](https://github.com/hpcloud/tail) looks stale, the last commit was made 4 years ago, and open PRs are waiting for review for a long time.

I suggest moving to grafana fork as a main dependency in repos where this dependency is used to get rid of replacement directives.
For example loki: https://github.com/grafana/loki/blob/9d5665e34aba3fb01cd17aa5c16c562af0ea8a06/go.mod#L311. This replacement is there for more than 3 years