### PR TITLE
fix retry logic to avoid stuck in loop

### DIFF
--- a/tail.go
+++ b/tail.go
@@ -222,6 +222,7 @@ func (tail *Tail) reopen(truncated bool) error {
 	}
 
 	tail.closeFile()
+	retries := 20
 	for {
 		var err error
 		tail.fileMtx.Lock()
@@ -251,7 +252,6 @@ func (tail *Tail) reopen(truncated bool) error {
 		}
 
 		// Check to see if we are trying to reopen and tail the exact same file (and it was not truncated).
-		retries := 20
 		if !truncated && cf != nil && os.SameFile(cf, nf) {
 			retries--
 			if retries <= 0 {


### PR DESCRIPTION
Fix a silly mistake in tail.go
The retry countdown do help keep promtail from stuck in loop, causing promtail stop read logs.

Related issue: https://github.com/grafana/loki/issues/3985