### PR TITLE
support exponential backoff when tailing files

### DIFF
--- a/tail.go
+++ b/tail.go
@@ -263,13 +263,8 @@ func (tail *Tail) reopen(truncated bool) error {
 				return errors.New("gave up trying to reopen log file with a different handle")
 			}
 
-			waitTime := tail.PollOptions.MinPollFrequency
-			if waitTime == 0 {
-				waitTime = watch.DefaultPollingFileWatcherOptions.MinPollFrequency
-			}
-
 			select {
-			case <-time.After(waitTime): // TODO: should this use backoff as well?
+			case <-time.After(watch.DefaultPollingFileWatcherOptions.MaxPollFrequency):
 				tail.closeFile()
 				continue
 			case <-tail.Tomb.Dying():

--- a/tail.go
+++ b/tail.go
@@ -63,6 +63,7 @@ type Config struct {
 	Poll        bool      // Poll for file changes instead of using inotify
 	Pipe        bool      // Is a named pipe (mkfifo)
 	RateLimiter *ratelimiter.LeakyBucket
+	PollOptions watch.PollingFileWatcherOptions
 
 	// Generic IO
 	Follow      bool // Continue looking for new lines (tail -f)
@@ -118,7 +119,11 @@ func TailFile(filename string, config Config) (*Tail, error) {
 	}
 
 	if t.Poll {
-		t.watcher = watch.NewPollingFileWatcher(filename)
+		watcher, err := watch.NewPollingFileWatcher(filename, config.PollOptions)
+		if err != nil {
+			return nil, err
+		}
+		t.watcher = watcher
 	} else {
 		t.watcher = watch.NewInotifyFileWatcher(filename)
 	}
@@ -257,8 +262,14 @@ func (tail *Tail) reopen(truncated bool) error {
 			if retries <= 0 {
 				return errors.New("gave up trying to reopen log file with a different handle")
 			}
+
+			waitTime := tail.PollOptions.MinPollFrequency
+			if waitTime == 0 {
+				waitTime = watch.DefaultPollingFileWatcherOptions.MinPollFrequency
+			}
+
 			select {
-			case <-time.After(watch.POLL_DURATION):
+			case <-time.After(waitTime): // TODO: should this use backoff as well?
 				tail.closeFile()
 				continue
 			case <-tail.Tomb.Dying():

--- a/tail_test.go
+++ b/tail_test.go
@@ -18,19 +18,19 @@ import (
 	"github.com/grafana/tail/watch"
 )
 
+var testPollingOptions = watch.PollingFileWatcherOptions{
+	// Use a smaller poll duration for faster test runs. Keep it below
+	// 100ms (which value is used as common delays for tests)
+	MinPollFrequency: 5 * time.Millisecond,
+	MaxPollFrequency: 5 * time.Millisecond,
+}
+
 func init() {
 	// Clear the temporary test directory
 	err := os.RemoveAll(".test")
 	if err != nil {
 		panic(err)
 	}
-}
-
-func TestMain(m *testing.M) {
-	// Use a smaller poll duration for faster test runs. Keep it below
-	// 100ms (which value is used as common delays for tests)
-	watch.POLL_DURATION = 5 * time.Millisecond
-	os.Exit(m.Run())
 }
 
 func TestMustExist(t *testing.T) {
@@ -341,7 +341,7 @@ func reOpen(t *testing.T, poll bool) {
 	tailTest.CreateFile("test.txt", "hello\nworld\n")
 	tail := tailTest.StartTail(
 		"test.txt",
-		Config{Follow: true, ReOpen: true, Poll: poll})
+		Config{Follow: true, ReOpen: true, Poll: poll, PollOptions: testPollingOptions})
 	content := []string{"hello", "world", "more", "data", "endofworld"}
 	go tailTest.VerifyTailOutput(tail, content, false)
 
@@ -415,7 +415,7 @@ func reSeek(t *testing.T, poll bool) {
 	tailTest.CreateFile("test.txt", "a really long string goes here\nhello\nworld\n")
 	tail := tailTest.StartTail(
 		"test.txt",
-		Config{Follow: true, ReOpen: false, Poll: poll})
+		Config{Follow: true, ReOpen: false, Poll: poll, PollOptions: testPollingOptions})
 
 	go tailTest.VerifyTailOutput(tail, []string{
 		"a really long string goes here", "hello", "world", "h311o", "w0r1d", "endofworld"}, false)
@@ -439,7 +439,7 @@ func TestTellRace(t *testing.T) {
 	tailTest := NewTailTest("tell-race", t)
 	tailTest.CreateFile("test.txt", "hello\nworld\n")
 
-	tail := tailTest.StartTail("test.txt", Config{Follow: true, ReOpen: true, Poll: true})
+	tail := tailTest.StartTail("test.txt", Config{Follow: true, ReOpen: true, Poll: true, PollOptions: testPollingOptions})
 
 	<-tail.Lines
 	<-tail.Lines
@@ -467,7 +467,7 @@ func TestSizeRace(t *testing.T) {
 	tailTest := NewTailTest("tell-race", t)
 	tailTest.CreateFile("test.txt", "hello\nworld\n")
 
-	tail := tailTest.StartTail("test.txt", Config{Follow: true, ReOpen: true, Poll: true})
+	tail := tailTest.StartTail("test.txt", Config{Follow: true, ReOpen: true, Poll: true, PollOptions: testPollingOptions})
 
 	<-tail.Lines
 	<-tail.Lines

--- a/watch/polling.go
+++ b/watch/polling.go
@@ -4,11 +4,13 @@
 package watch
 
 import (
-	"github.com/grafana/tail/util"
-	"gopkg.in/tomb.v1"
+	"fmt"
 	"os"
 	"runtime"
 	"time"
+
+	"github.com/grafana/tail/util"
+	"gopkg.in/tomb.v1"
 )
 
 // PollingFileWatcher polls the file for changes.
@@ -16,16 +18,50 @@ type PollingFileWatcher struct {
 	File     *os.File
 	Filename string
 	Size     int64
+	Options  PollingFileWatcherOptions
 }
 
-func NewPollingFileWatcher(filename string) *PollingFileWatcher {
-	fw := &PollingFileWatcher{nil, filename, 0}
-	return fw
+// PollingFileWatcherOptions customizes a PollingFileWatcher.
+type PollingFileWatcherOptions struct {
+	// MinPollFrequency and MaxPollFrequency specify how frequently a
+	// PollingFileWatcher should poll the file.
+	//
+	// PollingFileWatcher starts polling at MinPollFrequency, and will
+	// exponentially increase the polling frequency up to MaxPollFrequency if no
+	// new entries are found. The polling frequency is reset to MinPollFrequency
+	// whenever a new log entry is found or if the polled file changes.
+	MinPollFrequency, MaxPollFrequency time.Duration
 }
 
-var POLL_DURATION time.Duration
+// DefaultPollingFileWatcherOptions holds default values for
+// PollingFileWatcherOptions.
+var DefaultPollingFileWatcherOptions = PollingFileWatcherOptions{
+	MinPollFrequency: 250 * time.Millisecond,
+	MaxPollFrequency: 250 * time.Millisecond,
+}
+
+func NewPollingFileWatcher(filename string, opts PollingFileWatcherOptions) (*PollingFileWatcher, error) {
+	if opts == (PollingFileWatcherOptions{}) {
+		opts = DefaultPollingFileWatcherOptions
+	}
+
+	if opts.MinPollFrequency == 0 || opts.MaxPollFrequency == 0 {
+		return nil, fmt.Errorf("MinPollFrequency and MaxPollFrequency must be greater than 0")
+	} else if opts.MaxPollFrequency < opts.MinPollFrequency {
+		return nil, fmt.Errorf("MaxPollFrequency must be larger than MinPollFrequency")
+	}
+
+	return &PollingFileWatcher{
+		File:     nil,
+		Filename: filename,
+		Size:     0,
+		Options:  opts,
+	}, nil
+}
 
 func (fw *PollingFileWatcher) BlockUntilExists(t *tomb.Tomb) error {
+	bo := newPollBackoff(fw.Options)
+
 	for {
 		if _, err := os.Stat(fw.Filename); err == nil {
 			return nil
@@ -33,7 +69,8 @@ func (fw *PollingFileWatcher) BlockUntilExists(t *tomb.Tomb) error {
 			return err
 		}
 		select {
-		case <-time.After(POLL_DURATION):
+		case <-time.After(bo.WaitTime()):
+			bo.Backoff()
 			continue
 		case <-t.Dying():
 			return tomb.ErrDying
@@ -56,6 +93,8 @@ func (fw *PollingFileWatcher) ChangeEvents(t *tomb.Tomb, pos int64) (*FileChange
 
 	fw.Size = pos
 
+	bo := newPollBackoff(fw.Options)
+
 	go func() {
 		prevSize := fw.Size
 		for {
@@ -65,7 +104,7 @@ func (fw *PollingFileWatcher) ChangeEvents(t *tomb.Tomb, pos int64) (*FileChange
 			default:
 			}
 
-			time.Sleep(POLL_DURATION)
+			time.Sleep(bo.WaitTime())
 			deletePending, err := IsDeletePending(fw.File)
 			if err != nil {
 				util.Fatal("Failed to get file info %v: %v", fw.Filename, err)
@@ -105,12 +144,14 @@ func (fw *PollingFileWatcher) ChangeEvents(t *tomb.Tomb, pos int64) (*FileChange
 			if prevSize > 0 && prevSize > fw.Size {
 				changes.NotifyTruncated()
 				prevSize = fw.Size
+				bo.Reset()
 				continue
 			}
 			// File got bigger?
 			if prevSize > 0 && prevSize < fw.Size {
 				changes.NotifyModified()
 				prevSize = fw.Size
+				bo.Reset()
 				continue
 			}
 			prevSize = fw.Size
@@ -120,7 +161,12 @@ func (fw *PollingFileWatcher) ChangeEvents(t *tomb.Tomb, pos int64) (*FileChange
 			if modTime != prevModTime {
 				prevModTime = modTime
 				changes.NotifyModified()
+				bo.Reset()
+				continue
 			}
+
+			// File hasn't changed; increase backoff for next sleep.
+			bo.Backoff()
 		}
 	}()
 
@@ -137,6 +183,29 @@ func (fw *PollingFileWatcher) closeFile() {
 	}
 }
 
-func init() {
-	POLL_DURATION = 250 * time.Millisecond
+type pollBackoff struct {
+	current time.Duration
+	opts    PollingFileWatcherOptions
+}
+
+func newPollBackoff(opts PollingFileWatcherOptions) *pollBackoff {
+	return &pollBackoff{
+		current: opts.MinPollFrequency,
+		opts:    opts,
+	}
+}
+
+func (pb *pollBackoff) WaitTime() time.Duration {
+	return pb.current
+}
+
+func (pb *pollBackoff) Reset() {
+	pb.current = pb.opts.MinPollFrequency
+}
+
+func (pb *pollBackoff) Backoff() {
+	pb.current = pb.current * 2
+	if pb.current > pb.opts.MaxPollFrequency {
+		pb.current = pb.opts.MaxPollFrequency
+	}
 }


### PR DESCRIPTION
This commit extends the API of watch.NewPollingFileWatcher to accept options for how frequently files should be polled. By default, if the zero value is given, the previous value of polling every 250ms will be used.

The customizable polling frequency supports exponential backoff; the polling frequency will be doubled every time polling results in no changes up to hitting MaxPollFrequency. The polling frequency is reset to MinPollFrequency when a file change is detected.